### PR TITLE
Tweak Bandcamp link styling

### DIFF
--- a/salmagundi.html
+++ b/salmagundi.html
@@ -159,6 +159,6 @@
       speedDisplay.textContent = r.toFixed(2) + 'x';
     });
   </script>
-  <p style="font-size:1.5rem;text-align:center;">For more of <em>The Naked Cello</em>'s melodies, wander over to <a href="https://helenmountfort.bandcamp.com/album/the-naked-cello">Helen Mountfort's Bandcamp</a>.</p>
+  <p style="font-size:1rem;text-align:center;margin-top:auto;margin-bottom:0.5rem;color:#ccc;">For more of <em>The Naked Cello</em>'s melodies, wander over to <a href="https://helenmountfort.bandcamp.com/album/the-naked-cello">Helen Mountfort's Bandcamp</a>.</p>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- restyle Bandcamp link on salmagundi page to be smaller and tucked to the edge

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687d99fd64d0832f914d7f13f8c086b1