### PR TITLE
Fix note rendering in john.html

### DIFF
--- a/john.html
+++ b/john.html
@@ -52,14 +52,14 @@
     stave.setContext(context).draw();
 
     const notes = [
-      new VF.StaveNote({ clef: "bass", keys: ["C4"], duration: "8" }),
-      new VF.StaveNote({ clef: "bass", keys: ["Bb3"], duration: "8" }),
-      new VF.StaveNote({ clef: "bass", keys: ["C4"], duration: "8" }),
-      new VF.StaveNote({ clef: "bass", keys: ["Bb3"], duration: "8" }),
-      new VF.StaveNote({ clef: "bass", keys: ["C4"], duration: "8" }),
-      new VF.StaveNote({ clef: "bass", keys: ["Bb3"], duration: "8" }),
-      new VF.StaveNote({ clef: "bass", keys: ["C4"], duration: "8" }),
-      new VF.StaveNote({ clef: "bass", keys: ["Bb3"], duration: "8" })
+      new VF.StaveNote({ clef: "bass", keys: ["c/4"], duration: "8" }),
+      new VF.StaveNote({ clef: "bass", keys: ["bb/3"], duration: "8" }),
+      new VF.StaveNote({ clef: "bass", keys: ["c/4"], duration: "8" }),
+      new VF.StaveNote({ clef: "bass", keys: ["bb/3"], duration: "8" }),
+      new VF.StaveNote({ clef: "bass", keys: ["c/4"], duration: "8" }),
+      new VF.StaveNote({ clef: "bass", keys: ["bb/3"], duration: "8" }),
+      new VF.StaveNote({ clef: "bass", keys: ["c/4"], duration: "8" }),
+      new VF.StaveNote({ clef: "bass", keys: ["bb/3"], duration: "8" })
     ];
 
     const slur = new VF.StaveTie({


### PR DESCRIPTION
## Summary
- render notes correctly on the exercise page

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6886f554dde0832facceb27e345c3aea