### PR TITLE
Fix notation visibility and note keys

### DIFF
--- a/john.html
+++ b/john.html
@@ -23,6 +23,15 @@
     }
     #notation {
       margin-bottom: 2rem;
+      background: white;
+      padding: 1rem;
+      border-radius: 8px;
+    }
+    #notation svg {
+      width: 100%;
+      max-width: 500px;
+      height: auto;
+      display: block;
     }
     button {
       background: none;
@@ -52,14 +61,14 @@
     stave.setContext(context).draw();
 
     const notes = [
-      new VF.StaveNote({ clef: "bass", keys: ["c/4"], duration: "8" }),
-      new VF.StaveNote({ clef: "bass", keys: ["bb/3"], duration: "8" }),
-      new VF.StaveNote({ clef: "bass", keys: ["c/4"], duration: "8" }),
-      new VF.StaveNote({ clef: "bass", keys: ["bb/3"], duration: "8" }),
-      new VF.StaveNote({ clef: "bass", keys: ["c/4"], duration: "8" }),
-      new VF.StaveNote({ clef: "bass", keys: ["bb/3"], duration: "8" }),
-      new VF.StaveNote({ clef: "bass", keys: ["c/4"], duration: "8" }),
-      new VF.StaveNote({ clef: "bass", keys: ["bb/3"], duration: "8" })
+      new VF.StaveNote({ clef: "bass", keys: ["C4"], duration: "8" }),
+      new VF.StaveNote({ clef: "bass", keys: ["Bb3"], duration: "8" }),
+      new VF.StaveNote({ clef: "bass", keys: ["C4"], duration: "8" }),
+      new VF.StaveNote({ clef: "bass", keys: ["Bb3"], duration: "8" }),
+      new VF.StaveNote({ clef: "bass", keys: ["C4"], duration: "8" }),
+      new VF.StaveNote({ clef: "bass", keys: ["Bb3"], duration: "8" }),
+      new VF.StaveNote({ clef: "bass", keys: ["C4"], duration: "8" }),
+      new VF.StaveNote({ clef: "bass", keys: ["Bb3"], duration: "8" })
     ];
 
     const slur = new VF.StaveTie({


### PR DESCRIPTION
## Summary
- ensure SVG notation is visible in dark layout
- highlight notation container on dark background
- use VexFlow note names compatible with Tone.js

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6886f8975be8832f8c1eeb89aee14395