### PR TITLE
Fix VexFlow note key format

### DIFF
--- a/john.html
+++ b/john.html
@@ -61,28 +61,28 @@
       stave.setContext(context).draw();
 
       const notes = [
-        new VF.StaveNote({ clef: "bass", keys: ["C4"], duration: "8" }),
+        new VF.StaveNote({ clef: "bass", keys: ["c/4"], duration: "8" }),
         new VF.StaveNote({
           clef: "bass",
-          keys: ["Bb3"],
+          keys: ["bb/3"],
           duration: "8",
         }).addAccidental(0, new VF.Accidental("b")),
-        new VF.StaveNote({ clef: "bass", keys: ["C4"], duration: "8" }),
+        new VF.StaveNote({ clef: "bass", keys: ["c/4"], duration: "8" }),
         new VF.StaveNote({
           clef: "bass",
-          keys: ["Bb3"],
+          keys: ["bb/3"],
           duration: "8",
         }).addAccidental(0, new VF.Accidental("b")),
-        new VF.StaveNote({ clef: "bass", keys: ["C4"], duration: "8" }),
+        new VF.StaveNote({ clef: "bass", keys: ["c/4"], duration: "8" }),
         new VF.StaveNote({
           clef: "bass",
-          keys: ["Bb3"],
+          keys: ["bb/3"],
           duration: "8",
         }).addAccidental(0, new VF.Accidental("b")),
-        new VF.StaveNote({ clef: "bass", keys: ["C4"], duration: "8" }),
+        new VF.StaveNote({ clef: "bass", keys: ["c/4"], duration: "8" }),
         new VF.StaveNote({
           clef: "bass",
-          keys: ["Bb3"],
+          keys: ["bb/3"],
           duration: "8",
         }).addAccidental(0, new VF.Accidental("b")),
       ];


### PR DESCRIPTION
## Summary
- correct StaveNote key syntax in `john.html` so VexFlow can render notes

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6887c33eae60832f808c7275fdbf9c49