### PR TITLE
Fix VexFlow CDN path

### DIFF
--- a/john.html
+++ b/john.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Fouillard Web Exercise</title>
-    <script src="https://unpkg.com/vexflow/releases/vexflow-min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/vexflow@5.0.0/build/cjs/vexflow.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/tone/14.8.39/Tone.min.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/@magenta/music@1.23.1/es6/core.js"></script>
     <style>


### PR DESCRIPTION
## Summary
- load VexFlow from jsDelivr instead of a missing path on unpkg

## Testing
- `true`


------
https://chatgpt.com/codex/tasks/task_e_6887d0f9d6a4832f8fd7ebd9474defe0