### PR TITLE
Add song links to index

### DIFF
--- a/index.html
+++ b/index.html
@@ -10,14 +10,46 @@
       height: 100%;
       background: black;
       overflow: hidden;
+      color: white;
+      font-family: "Cormorant Garamond", serif;
     }
     canvas {
       display: block;
+      position: fixed;
+      top: 0;
+      left: 0;
+      width: 100%;
+      height: 100%;
+    }
+    #links {
+      position: absolute;
+      top: 1rem;
+      left: 1rem;
+      z-index: 1;
+    }
+    #links ul {
+      list-style: none;
+      margin: 0;
+      padding: 0;
+    }
+    #links li {
+      margin-bottom: 0.5rem;
+    }
+    #links a {
+      color: white;
+      text-decoration: none;
     }
   </style>
 </head>
 <body>
 <canvas id="stars"></canvas>
+<nav id="links">
+  <ul>
+    <li><a href="bedrock.html">bedrock</a></li>
+    <li><a href="john.html">john</a></li>
+    <li><a href="salmagundi.html">salmagundi</a></li>
+  </ul>
+</nav>
 <script>
   const canvas = document.getElementById("stars");
   const ctx = canvas.getContext("2d");


### PR DESCRIPTION
## Summary
- Add links to existing song pages (bedrock, john, salmagundi) on the index page.
- Style home page so song list overlays starry background.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689ecaf3f744832f966a6eba3de0b572