### PR TITLE
Enable adding multiple sequential loops

### DIFF
--- a/audiolooper.js
+++ b/audiolooper.js
@@ -1,13 +1,13 @@
 // Shared audio playback and looping controls
 // Designed to be used on pages with elements:
-// #audio, #loop-btn, #play-btn, #start, #end, #speed, #speed-display
+// #audio, #loop-btn, #play-btn, #loops, #add-loop, #speed, #speed-display
 
 (function () {
   const audio = document.getElementById('audio');
   const loopBtn = document.getElementById('loop-btn');
   const playBtn = document.getElementById('play-btn');
-  const startInput = document.getElementById('start');
-  const endInput = document.getElementById('end');
+  const loopsContainer = document.getElementById('loops');
+  const addLoopBtn = document.getElementById('add-loop');
   const speedInput = document.getElementById('speed');
   const speedDisplay = document.getElementById('speed-display');
 
@@ -23,6 +23,7 @@
   let loopActive = false;
   let playActive = false;
   let loopHandler = null;
+  let currentLoopIndex = 0;
 
   function parseTime(t) {
     const parts = t.split(':');
@@ -30,18 +31,68 @@
     return parseInt(parts[0], 10) * 60 + parseFloat(parts[1]);
   }
 
+  function formatTime(sec) {
+    const m = Math.floor(sec / 60);
+    const s = Math.floor(sec % 60).toString().padStart(2, '0');
+    return `${m}:${s}`;
+  }
+
+  let loops = [];
+  if (loopsContainer) {
+    loops = Array.from(loopsContainer.querySelectorAll('.loop')).map((el) => ({
+      start: el.querySelector('.start'),
+      end: el.querySelector('.end')
+    }));
+  }
+
+  if (addLoopBtn && loopsContainer) {
+    addLoopBtn.addEventListener('click', () => {
+      const last = loops[loops.length - 1];
+      const startVal = last.end.value;
+      const startSec = parseTime(startVal);
+      const endSec = startSec + 10;
+
+      const loopDiv = document.createElement('div');
+      loopDiv.className = 'loop';
+
+      const startLabel = document.createElement('label');
+      startLabel.textContent = 'start ';
+      const startInput = document.createElement('input');
+      startInput.type = 'text';
+      startInput.size = 5;
+      startInput.className = 'start';
+      startInput.value = startVal;
+      startLabel.appendChild(startInput);
+
+      const endLabel = document.createElement('label');
+      endLabel.textContent = 'end ';
+      const endInput = document.createElement('input');
+      endInput.type = 'text';
+      endInput.size = 5;
+      endInput.className = 'end';
+      endInput.value = formatTime(endSec);
+      endLabel.appendChild(endInput);
+
+      loopDiv.appendChild(startLabel);
+      loopDiv.appendChild(endLabel);
+      loopsContainer.appendChild(loopDiv);
+      loops.push({ start: startInput, end: endInput });
+    });
+  }
+
   loopBtn.addEventListener('click', () => {
     if (!loopActive) {
       playActive = false;
       playBtn.textContent = 'play piece';
       audio.pause();
-      const start = parseTime(startInput.value);
+      currentLoopIndex = 0;
+      const start = parseTime(loops[0].start.value);
       audio.currentTime = start;
       loopHandler = () => {
-        const s = parseTime(startInput.value);
-        const e = parseTime(endInput.value);
+        const e = parseTime(loops[currentLoopIndex].end.value);
         if (audio.currentTime >= e) {
-          audio.currentTime = s;
+          currentLoopIndex = (currentLoopIndex + 1) % loops.length;
+          audio.currentTime = parseTime(loops[currentLoopIndex].start.value);
         }
       };
       audio.addEventListener('timeupdate', loopHandler);

--- a/bedrock.html
+++ b/bedrock.html
@@ -66,9 +66,14 @@
   </div>
 
   <div class="controls">
+    <div id="loops">
+      <div class="loop">
+        <label>start <input class="start" type="text" value="0:00" size="5"></label>
+        <label>end <input class="end" type="text" value="0:10" size="5"></label>
+      </div>
+    </div>
     <div>
-      <label>start <input id="start" type="text" value="0:00" size="5"></label>
-      <label>end <input id="end" type="text" value="0:10" size="5"></label>
+      <button id="add-loop">+</button>
     </div>
     <div>
       <label style="margin-right:0.5rem;">speed <span id="speed-display">1x</span></label>

--- a/salmagundi.html
+++ b/salmagundi.html
@@ -66,9 +66,14 @@
   </div>
 
   <div class="controls">
+    <div id="loops">
+      <div class="loop">
+        <label>start <input class="start" type="text" value="0:00" size="5"></label>
+        <label>end <input class="end" type="text" value="0:10" size="5"></label>
+      </div>
+    </div>
     <div>
-      <label>start <input id="start" type="text" value="0:00" size="5"></label>
-      <label>end <input id="end" type="text" value="0:10" size="5"></label>
+      <button id="add-loop">+</button>
     </div>
     <div>
       <label style="margin-right:0.5rem;">speed <span id="speed-display">1x</span></label>


### PR DESCRIPTION
## Summary
- allow multiple user-defined loops with a `+` button
- play added loops sequentially during practice
- update example pages to host dynamic loop inputs

## Testing
- `npm test` *(fails: ENOENT package.json)*
- `node --check audiolooper.js`


------
https://chatgpt.com/codex/tasks/task_e_689ecc2c9114832f9b0d8ca8d87d79be