### PR TITLE
Fix initial loop control alignment

### DIFF
--- a/audiolooper.js
+++ b/audiolooper.js
@@ -85,6 +85,11 @@
         btn = document.createElement('button');
         btn.textContent = 'loop section';
         btn.className = 'loop-btn';
+        // Remove any trailing whitespace nodes so the button aligns
+        // consistently with buttons added later via JavaScript.
+        while (el.lastChild && el.lastChild.nodeType === Node.TEXT_NODE) {
+          el.removeChild(el.lastChild);
+        }
         el.appendChild(btn);
       }
       btn.dataset.index = i;


### PR DESCRIPTION
## Summary
- Remove trailing whitespace when adding loop control buttons to existing loops so the first loop's button aligns with subsequently added controls

## Testing
- `node --check audiolooper.js`


------
https://chatgpt.com/codex/tasks/task_e_689ed22a4c24832f98df774347dcbd08