### PR TITLE
Support predefined loop sections in AudioLooper

### DIFF
--- a/audiolooper.js
+++ b/audiolooper.js
@@ -2,7 +2,7 @@
 // Designed to be used on pages with elements:
 // #audio, #play-btn, #loops, #add-loop, #speed, #speed-display
 
-(function () {
+function AudioLooper(initialTimes = []) {
   const audio = document.getElementById('audio');
   const playBtn = document.getElementById('play-btn');
   const loopsContainer = document.getElementById('loops');
@@ -76,68 +76,76 @@
     }
   }
 
+  function createLoop(startVal, endVal) {
+    const loopDiv = document.createElement('div');
+    loopDiv.className = 'loop';
+
+    const startLabel = document.createElement('label');
+    startLabel.textContent = 'start ';
+    const startInput = document.createElement('input');
+    startInput.type = 'text';
+    startInput.size = 5;
+    startInput.className = 'start';
+    startInput.value = typeof startVal === 'number' ? formatTime(startVal) : startVal;
+    startLabel.appendChild(startInput);
+
+    const endLabel = document.createElement('label');
+    endLabel.textContent = 'end ';
+    const endInput = document.createElement('input');
+    endInput.type = 'text';
+    endInput.size = 5;
+    endInput.className = 'end';
+    endInput.value = typeof endVal === 'number' ? formatTime(endVal) : endVal;
+    endLabel.appendChild(endInput);
+
+    const loopButton = document.createElement('button');
+    loopButton.textContent = 'loop section';
+    loopButton.className = 'loop-btn';
+
+    loopDiv.appendChild(startLabel);
+    loopDiv.appendChild(endLabel);
+    loopDiv.appendChild(loopButton);
+    loopsContainer.appendChild(loopDiv);
+
+    const index = loops.length;
+    loopButton.dataset.index = index;
+    loopButton.addEventListener('click', () => handleLoopButton(index));
+    loops.push({ start: startInput, end: endInput, button: loopButton });
+  }
+
   if (loopsContainer) {
-    loops = Array.from(loopsContainer.querySelectorAll('.loop')).map((el, i) => {
-      const start = el.querySelector('.start');
-      const end = el.querySelector('.end');
-      let btn = el.querySelector('.loop-btn');
-      if (!btn) {
-        btn = document.createElement('button');
-        btn.textContent = 'loop section';
-        btn.className = 'loop-btn';
-        // Remove any trailing whitespace nodes so the button aligns
-        // consistently with buttons added later via JavaScript.
-        while (el.lastChild && el.lastChild.nodeType === Node.TEXT_NODE) {
-          el.removeChild(el.lastChild);
+    if (initialTimes.length > 0) {
+      loopsContainer.innerHTML = '';
+      initialTimes.forEach(([s, e]) => createLoop(s, e));
+    } else {
+      loops = Array.from(loopsContainer.querySelectorAll('.loop')).map((el, i) => {
+        const start = el.querySelector('.start');
+        const end = el.querySelector('.end');
+        let btn = el.querySelector('.loop-btn');
+        if (!btn) {
+          btn = document.createElement('button');
+          btn.textContent = 'loop section';
+          btn.className = 'loop-btn';
+          // Remove any trailing whitespace nodes so the button aligns
+          // consistently with buttons added later via JavaScript.
+          while (el.lastChild && el.lastChild.nodeType === Node.TEXT_NODE) {
+            el.removeChild(el.lastChild);
+          }
+          el.appendChild(btn);
         }
-        el.appendChild(btn);
-      }
-      btn.dataset.index = i;
-      btn.addEventListener('click', () => handleLoopButton(i));
-      return { start, end, button: btn };
-    });
+        btn.dataset.index = i;
+        btn.addEventListener('click', () => handleLoopButton(i));
+        return { start, end, button: btn };
+      });
+    }
   }
 
   if (addLoopBtn && loopsContainer) {
     addLoopBtn.addEventListener('click', () => {
-      const last = loops[loops.length - 1];
-      const startVal = last.end.value;
+      const startVal = loops.length ? loops[loops.length - 1].end.value : '0:00';
       const startSec = parseTime(startVal);
       const endSec = startSec + 10;
-
-      const loopDiv = document.createElement('div');
-      loopDiv.className = 'loop';
-
-      const startLabel = document.createElement('label');
-      startLabel.textContent = 'start ';
-      const startInput = document.createElement('input');
-      startInput.type = 'text';
-      startInput.size = 5;
-      startInput.className = 'start';
-      startInput.value = startVal;
-      startLabel.appendChild(startInput);
-
-      const endLabel = document.createElement('label');
-      endLabel.textContent = 'end ';
-      const endInput = document.createElement('input');
-      endInput.type = 'text';
-      endInput.size = 5;
-      endInput.className = 'end';
-      endInput.value = formatTime(endSec);
-      endLabel.appendChild(endInput);
-
-      const loopButton = document.createElement('button');
-      loopButton.textContent = 'loop section';
-      loopButton.className = 'loop-btn';
-
-      loopDiv.appendChild(startLabel);
-      loopDiv.appendChild(endLabel);
-      loopDiv.appendChild(loopButton);
-      loopsContainer.appendChild(loopDiv);
-      const index = loops.length;
-      loopButton.dataset.index = index;
-      loopButton.addEventListener('click', () => handleLoopButton(index));
-      loops.push({ start: startInput, end: endInput, button: loopButton });
+      createLoop(startVal, formatTime(endSec));
     });
   }
 
@@ -162,5 +170,7 @@
     audio.playbackRate = r;
     speedDisplay.textContent = r.toFixed(2) + 'x';
   });
-})();
+}
+
+window.AudioLooper = AudioLooper;
 

--- a/bedrock.html
+++ b/bedrock.html
@@ -66,12 +66,7 @@
   </div>
 
   <div class="controls">
-    <div id="loops">
-      <div class="loop">
-        <label>start <input class="start" type="text" value="0:00" size="5"></label>
-        <label>end <input class="end" type="text" value="0:10" size="5"></label>
-      </div>
-    </div>
+    <div id="loops"></div>
     <div>
       <button id="add-loop">+</button>
     </div>
@@ -90,6 +85,13 @@
   </audio>
 
   <script src="audiolooper.js"></script>
+  <script>
+    AudioLooper([
+      [0, 10],
+      [10, 20],
+      [20, 30]
+    ]);
+  </script>
   <p style="font-size:1rem;text-align:center;margin-top:auto;margin-bottom:0.5rem;color:#ccc;">For more of <em>The Naked Cello</em>'s melodies, wander over to <a href="https://helenmountfort.bandcamp.com/album/the-naked-cello">Helen Mountfort's Bandcamp</a>.</p>
 </body>
 </html>

--- a/salmagundi.html
+++ b/salmagundi.html
@@ -66,12 +66,7 @@
   </div>
 
   <div class="controls">
-    <div id="loops">
-      <div class="loop">
-        <label>start <input class="start" type="text" value="0:00" size="5"></label>
-        <label>end <input class="end" type="text" value="0:10" size="5"></label>
-      </div>
-    </div>
+    <div id="loops"></div>
     <div>
       <button id="add-loop">+</button>
     </div>
@@ -90,6 +85,11 @@
   </audio>
 
   <script src="audiolooper.js"></script>
+  <script>
+    AudioLooper([
+      [0, 10]
+    ]);
+  </script>
   <p style="font-size:1rem;text-align:center;margin-top:auto;margin-bottom:0.5rem;color:#ccc;">For more of <em>The Naked Cello</em>'s melodies, wander over to <a href="https://helenmountfort.bandcamp.com/album/the-naked-cello">Helen Mountfort's Bandcamp</a>.</p>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- Allow AudioLooper to accept predefined loop start/end times
- Prebuild three loops for Bedrock and default loop for Salmagundi
- Keep ability for users to add additional loop sections

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689eda487c0c832f9ee34db745319b90