### PR TITLE
Predefine loop timings for bedrock

### DIFF
--- a/bedrock.html
+++ b/bedrock.html
@@ -71,6 +71,18 @@
         <label>start <input class="start" type="text" value="0:00" size="5"></label>
         <label>end <input class="end" type="text" value="0:10" size="5"></label>
       </div>
+      <div class="loop">
+        <label>start <input class="start" type="text" value="0:10" size="5"></label>
+        <label>end <input class="end" type="text" value="0:22" size="5"></label>
+      </div>
+      <div class="loop">
+        <label>start <input class="start" type="text" value="0:22" size="5"></label>
+        <label>end <input class="end" type="text" value="0:28" size="5"></label>
+      </div>
+      <div class="loop">
+        <label>start <input class="start" type="text" value="0:28" size="5"></label>
+        <label>end <input class="end" type="text" value="0:39" size="5"></label>
+      </div>
     </div>
     <div>
       <button id="add-loop">+</button>


### PR DESCRIPTION
## Summary
- preconfigure four loop sections for the bedrock audio page

## Testing
- `npm test` (fails: missing package.json)


------
https://chatgpt.com/codex/tasks/task_e_689edc5b9eec832fae0e248911d67268