### PR TITLE
Add Flowstone page with audio looper

### DIFF
--- a/flowstone.html
+++ b/flowstone.html
@@ -1,0 +1,95 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>flowstone</title>
+  <style>
+    body {
+      margin: 0;
+      background: black;
+      color: white;
+      font-family: "Cormorant Garamond", serif;
+      font-size: 2rem;
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      justify-content: center;
+      gap: 2rem;
+      height: 100vh;
+    }
+
+    .controls {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+      align-items: center;
+    }
+
+    label {
+      font-size: 1.2rem;
+    }
+
+    input {
+      padding: 0.25em 0.5em;
+      font-size: 1rem;
+      font-family: inherit;
+      background: black;
+      color: white;
+      border: 1px solid #666;
+    }
+
+    button {
+      background: none;
+      border: 1px solid #666;
+      color: #ddd;
+      font-family: inherit;
+      font-size: 1.2rem;
+      padding: 0.5em 1em;
+      cursor: pointer;
+    }
+
+    .feather {
+      width: 2em;
+      height: 2em;
+    }
+
+    input[type="range"] {
+      width: 10em;
+    }
+  </style>
+</head>
+<body>
+  <div id="title" style="display:flex;align-items:center;gap:0.4rem;font-size:3rem;">
+    <span>flowstone</span>
+    <img src="feather.svg" alt="feather" class="feather">
+  </div>
+
+  <div class="controls">
+    <div id="loops">
+      <div class="loop">
+        <label>start <input class="start" type="text" value="0:00" size="5"></label>
+        <label>end <input class="end" type="text" value="0:10" size="5"></label>
+      </div>
+    </div>
+    <div>
+      <button id="add-loop">+</button>
+    </div>
+    <div>
+      <label style="margin-right:0.5rem;">speed <span id="speed-display">1x</span></label>
+      <input id="speed" type="range" min="0.5" max="1.5" step="0.05" value="1">
+    </div>
+    <div>
+      <button id="play-btn">play piece</button>
+    </div>
+  </div>
+
+  <audio id="audio" preload="auto">
+    <source src="flowstone.mp3" type="audio/mpeg">
+    Your browser does not support the audio element.
+  </audio>
+
+  <script src="audiolooper.js"></script>
+  <p style="font-size:1rem;text-align:center;margin-top:auto;margin-bottom:0.5rem;color:#ccc;">For more of <em>The Naked Cello</em>'s melodies, wander over to <a href="https://helenmountfort.bandcamp.com/album/the-naked-cello">Helen Mountfort's Bandcamp</a>.</p>
+</body>
+</html>

--- a/index.html
+++ b/index.html
@@ -46,6 +46,7 @@
 <nav id="links">
   <ul>
     <li><a href="bedrock.html">bedrock</a></li>
+    <li><a href="flowstone.html">flowstone</a></li>
     <li><a href="john.html">john</a></li>
     <li><a href="salmagundi.html">salmagundi</a></li>
   </ul>


### PR DESCRIPTION
## Summary
- add Flowstone track page with built-in audio looper controls
- link Flowstone from the main index page navigation

## Testing
- `npm test` *(fails: ENOENT no package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689f082292fc832f9a1ddb3607978a18